### PR TITLE
lock alpine to 3.6 to fix missing requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.6
 
 MAINTAINER Patrick Pokatilo <docker-hub@shyxormz.net>
 


### PR DESCRIPTION
This fix Error "missing requirements"